### PR TITLE
feat: add termos de uso e politica de privacidade

### DIFF
--- a/src/app/auth/auth.page.html
+++ b/src/app/auth/auth.page.html
@@ -11,6 +11,13 @@
       <div class="button google" (click)="signIn('google')"><ion-icon name="logo-google"></ion-icon>Entrar com Google</div>
       <div *ngIf="platform.is('ios')" class="button apple" (click)="signIn('apple')"><ion-icon name="logo-apple"></ion-icon>Entrar com Apple ID</div>
     </div>
+    <div class="terms-container">
+      <ion-item>
+        <ion-checkbox [(ngModel)]="acceptTerms">
+          <ion-label>Eu declaro que li e aceito os <a (click)="openTerms()">Termos de Uso</a> e a <a (click)="openPrivacyPolicy()">Política de Privacidade</a></ion-label>
+        </ion-checkbox>
+      </ion-item>
+    </div>
   </div>
   <div class="credits">
     <div>Desenvolvido com carinho por: UTFPR</div>

--- a/src/app/auth/auth.page.scss
+++ b/src/app/auth/auth.page.scss
@@ -45,7 +45,7 @@ ion-content {
   }
   .actions-container{
     position: absolute;
-    bottom: 10%;
+    bottom: 20%;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -85,8 +85,55 @@ ion-content {
         color: #fff;
       }
     }
-
   }
+
+  .terms-container {
+    position: absolute;
+    width: 80%;
+    bottom: 10%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-family: 'Roboto', sans-serif;
+  
+    ion-item {
+      --background: transparent;
+      --padding-start: 0;
+      --inner-padding-end: 0;
+      --border-width: 0;
+      --inner-border-width: 0;
+      width: 100%;
+  
+      ion-checkbox {
+        --size: 20px;
+        --background-checked: #48a1ff;
+        --border-color-checked: #48a1ff;
+        --border-color: #000;
+        --border-width: 2px;
+        margin-left: auto;
+      }
+  
+      ion-label {
+        font-size: 14px;
+        color: #000;
+        font-weight: 500;
+        display: flex;
+        align-items: center;
+        white-space: normal;
+  
+        a {
+          color: #48a1ff;
+          text-decoration: none;
+          font-weight: bold;
+  
+          &:hover {
+            text-decoration: underline;
+          }
+        }
+      }
+    }
+  }
+
   .credits {
     position: absolute;
     text-align: center;

--- a/src/app/auth/auth.page.ts
+++ b/src/app/auth/auth.page.ts
@@ -1,6 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { AuthService } from '../services/auth/auth.service';
-import {Platform} from "@ionic/angular";
+import {ModalController, Platform} from "@ionic/angular";
+import { TermsOfUseModalComponent } from '../terms-modal/terms-of-use-modal/terms-of-use-modal.component';
+import { PrivacyPolicyModalComponent } from '../terms-modal/privacy-policy-modal/privacy-policy-modal.component';
+import { TermsOfUseService } from '../services/terms-of-use/terms-of-use.service';
+import { UserService } from '../services/user/user.service';
 
 @Component({
   selector: 'app-auth',
@@ -8,28 +12,59 @@ import {Platform} from "@ionic/angular";
   styleUrls: ['./auth.page.scss'],
 })
 export class AuthPage {
+  acceptTerms: boolean = false;
 
   constructor(
     private _authService: AuthService,
-    public platform: Platform
+    public platform: Platform,
+    private modalController: ModalController,
+    private _termsService: TermsOfUseService,
+    private _userService: UserService,
   ) { }
 
-  async signIn(method:string) {
-    switch (method) {
-      case 'google': {
-        return this._authService.signInWithGoogle();
-      }
-      case 'facebook': {
-        return this._authService.signInWithFacebook();
-      }
-      default: {
+  async signIn(method: string) {
+    if (!this.acceptTerms) {
+        alert('Você precisa aceitar os termos de uso para continuar.');
         return;
-      }
     }
-  }
+
+    let user;
+
+    switch (method) {
+        case 'google': {
+            user = await this._authService.signInWithGoogle();
+            break;
+        }
+        case 'facebook': {
+            user = await this._authService.signInWithFacebook();
+            break;
+        }
+        default: {
+            return;
+        }
+    }
+
+    if (user) {
+        await this._termsService.acceptTerms(user.user.id);
+    }
+}
 
   async signOut() {
     await this._authService.signOut();
   }
 
+  async openTerms() {
+    const modal = await this.modalController.create({
+      component: TermsOfUseModalComponent,
+    });
+    await modal.present();
+  }
+
+  async openPrivacyPolicy() {
+    console.log('Abrir Política de Privacidade');
+    const modal = await this.modalController.create({
+      component: PrivacyPolicyModalComponent,
+    });
+    await modal.present();
+  }
 }

--- a/src/app/auth/auth.page.ts
+++ b/src/app/auth/auth.page.ts
@@ -61,7 +61,6 @@ export class AuthPage {
   }
 
   async openPrivacyPolicy() {
-    console.log('Abrir Política de Privacidade');
     const modal = await this.modalController.create({
       component: PrivacyPolicyModalComponent,
     });

--- a/src/app/services/terms-of-use/terms-of-use.service.spec.ts
+++ b/src/app/services/terms-of-use/terms-of-use.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { TermsOfUseService } from './terms-of-use.service';
+
+describe('TermsOfUseService', () => {
+  let service: TermsOfUseService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(TermsOfUseService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/terms-of-use/terms-of-use.service.ts
+++ b/src/app/services/terms-of-use/terms-of-use.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { SupabaseClient } from '@supabase/supabase-js';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TermsOfUseService {
+
+  constructor(
+    private _supabase: SupabaseClient
+  ) { }
+
+  async acceptTerms(userId: string) {
+    const { data, error } = await this._supabase.from('terms_acceptance').insert([{ user_id: userId }]);
+    if (error) {
+      throw error;
+    }
+    return data;
+  }
+}

--- a/src/app/terms-modal/privacy-policy-modal/privacy-policy-modal.component.html
+++ b/src/app/terms-modal/privacy-policy-modal/privacy-policy-modal.component.html
@@ -1,0 +1,118 @@
+<h2><span style="color: rgb(68, 68, 68)">Política Privacidade</span></h2>
+<p>
+  <span style="color: rgb(68, 68, 68)"
+    >A sua privacidade é importante para nós. É política do NeuroApp respeitar a
+    sua privacidade em relação a qualquer informação sua que possamos coletar no
+    site <a href="https://neuroapp.sa.pinheiro.tech/auth">NeuroApp</a>, e outros
+    sites que possuímos e operamos.</span
+  >
+</p>
+<p>
+  <span style="color: rgb(68, 68, 68)"
+    >Solicitamos informações pessoais apenas quando realmente precisamos delas
+    para lhe fornecer um serviço. Fazemo-lo por meios justos e legais, com o seu
+    conhecimento e consentimento. Também informamos por que estamos coletando e
+    como será usado.</span
+  >
+</p>
+<p>
+  <span style="color: rgb(68, 68, 68)"
+    >Apenas retemos as informações coletadas pelo tempo necessário para fornecer
+    o serviço solicitado. Quando armazenamos dados, protegemos dentro de meios
+    comercialmente aceitáveis ​​para evitar perdas e roubos, bem como acesso,
+    divulgação, cópia, uso ou modificação não autorizados.</span
+  >
+</p>
+<p>
+  <span style="color: rgb(68, 68, 68)"
+    >Não compartilhamos informações de identificação pessoal publicamente ou com
+    terceiros, exceto quando exigido por lei.</span
+  >
+</p>
+<p>
+  <span style="color: rgb(68, 68, 68)"
+    >O nosso site pode ter links para sites externos que não são operados por
+    nós. Esteja ciente de que não temos controle sobre o conteúdo e práticas
+    desses sites e não podemos aceitar responsabilidade por suas
+    respectivas&nbsp;</span
+  ><a
+    href="https://politicaprivacidade.com/"
+    rel="noopener noreferrer"
+    target="_blank"
+    style="background-color: transparent; color: rgb(68, 68, 68)"
+    >políticas de privacidade</a
+  ><span style="color: rgb(68, 68, 68)">.</span>
+</p>
+<p>
+  <span style="color: rgb(68, 68, 68)"
+    >Você é livre para recusar a nossa solicitação de informações pessoais,
+    entendendo que talvez não possamos fornecer alguns dos serviços
+    desejados.</span
+  >
+</p>
+<p>
+  <span style="color: rgb(68, 68, 68)"
+    >O uso continuado de nosso site será considerado como aceitação de nossas
+    práticas em torno de privacidade e informações pessoais. Se você tiver
+    alguma dúvida sobre como lidamos com dados do usuário e informações
+    pessoais, entre em contacto connosco.</span
+  >
+</p>
+<p><span style="color: rgb(68, 68, 68)"></span></p>
+<h3><span style="color: rgb(68, 68, 68)">Compromisso do Usuário</span></h3>
+<p>
+  <span style="color: rgb(68, 68, 68)"
+    >O usuário se compromete a fazer uso adequado dos conteúdos e da informação
+    que o NeuroApp oferece no site e com caráter enunciativo, mas não
+    limitativo:</span
+  >
+</p>
+<ul>
+  <li>
+    <span style="color: rgb(68, 68, 68)"
+      >A) Não se envolver em atividades que sejam ilegais ou contrárias à boa fé
+      a à ordem pública;</span
+    >
+  </li>
+  <li>
+    <span style="color: rgb(68, 68, 68)"
+      >B) Não difundir propaganda ou conteúdo de natureza racista, xenofóbica, </span
+    ><span style="color: rgb(33, 37, 41)"
+      ><a
+        href="https://betnacionalbrasil.br.com"
+        style="
+          color: inherit !important;
+          text-decoration: none !important;
+          font-size: inherit !important;
+        "
+        >Bet Nacional</a
+      ></span
+    ><span style="color: rgb(68, 68, 68)">
+      ou azar, qualquer tipo de pornografia ilegal, de apologia ao terrorismo ou
+      contra os direitos humanos;</span
+    >
+  </li>
+  <li>
+    <span style="color: rgb(68, 68, 68)"
+      >C) Não causar danos aos sistemas físicos (hardwares) e lógicos
+      (softwares) do NeuroApp, de seus fornecedores ou terceiros, para
+      introduzir ou disseminar vírus informáticos ou quaisquer outros sistemas
+      de hardware ou software que sejam capazes de causar danos anteriormente
+      mencionados.</span
+    >
+  </li>
+</ul>
+<h3><span style="color: rgb(68, 68, 68)">Mais informações</span></h3>
+<p>
+  <span style="color: rgb(68, 68, 68)"
+    >Esperemos que esteja esclarecido e, como mencionado anteriormente, se
+    houver algo que você não tem certeza se precisa ou não, geralmente é mais
+    seguro deixar os cookies ativados, caso interaja com um dos recursos que
+    você usa em nosso site.</span
+  >
+</p>
+<p>
+  <span style="color: rgb(68, 68, 68)"
+    >Esta política é efetiva a partir de&nbsp;17 March 2025 11:57</span
+  >
+</p>

--- a/src/app/terms-modal/privacy-policy-modal/privacy-policy-modal.component.html
+++ b/src/app/terms-modal/privacy-policy-modal/privacy-policy-modal.component.html
@@ -1,5 +1,6 @@
-<div class="modal" (click)="closeModal($event)">
-  <div class="modal-content" (click)="closeModal($event)">
+<div class="modal" (click)="closeModal()">
+  <div class="modal-content">
+    <button class="close-modal" (click)="closeModal()">&times;</button>
     <h2>1. Política de Privacidade</h2>
     <p>
       A sua privacidade é importante para nós. É política do NeuroApp respeitar a sua privacidade em relação a qualquer informação sua que possamos coletar no site <a href="https://neuroapp.sa.pinheiro.tech/auth">NeuroApp</a>, e outros sites que possuímos e operamos.

--- a/src/app/terms-modal/privacy-policy-modal/privacy-policy-modal.component.html
+++ b/src/app/terms-modal/privacy-policy-modal/privacy-policy-modal.component.html
@@ -1,118 +1,64 @@
-<h2><span style="color: rgb(68, 68, 68)">Política Privacidade</span></h2>
-<p>
-  <span style="color: rgb(68, 68, 68)"
-    >A sua privacidade é importante para nós. É política do NeuroApp respeitar a
-    sua privacidade em relação a qualquer informação sua que possamos coletar no
-    site <a href="https://neuroapp.sa.pinheiro.tech/auth">NeuroApp</a>, e outros
-    sites que possuímos e operamos.</span
-  >
-</p>
-<p>
-  <span style="color: rgb(68, 68, 68)"
-    >Solicitamos informações pessoais apenas quando realmente precisamos delas
-    para lhe fornecer um serviço. Fazemo-lo por meios justos e legais, com o seu
-    conhecimento e consentimento. Também informamos por que estamos coletando e
-    como será usado.</span
-  >
-</p>
-<p>
-  <span style="color: rgb(68, 68, 68)"
-    >Apenas retemos as informações coletadas pelo tempo necessário para fornecer
-    o serviço solicitado. Quando armazenamos dados, protegemos dentro de meios
-    comercialmente aceitáveis ​​para evitar perdas e roubos, bem como acesso,
-    divulgação, cópia, uso ou modificação não autorizados.</span
-  >
-</p>
-<p>
-  <span style="color: rgb(68, 68, 68)"
-    >Não compartilhamos informações de identificação pessoal publicamente ou com
-    terceiros, exceto quando exigido por lei.</span
-  >
-</p>
-<p>
-  <span style="color: rgb(68, 68, 68)"
-    >O nosso site pode ter links para sites externos que não são operados por
-    nós. Esteja ciente de que não temos controle sobre o conteúdo e práticas
-    desses sites e não podemos aceitar responsabilidade por suas
-    respectivas&nbsp;</span
-  ><a
-    href="https://politicaprivacidade.com/"
-    rel="noopener noreferrer"
-    target="_blank"
-    style="background-color: transparent; color: rgb(68, 68, 68)"
-    >políticas de privacidade</a
-  ><span style="color: rgb(68, 68, 68)">.</span>
-</p>
-<p>
-  <span style="color: rgb(68, 68, 68)"
-    >Você é livre para recusar a nossa solicitação de informações pessoais,
-    entendendo que talvez não possamos fornecer alguns dos serviços
-    desejados.</span
-  >
-</p>
-<p>
-  <span style="color: rgb(68, 68, 68)"
-    >O uso continuado de nosso site será considerado como aceitação de nossas
-    práticas em torno de privacidade e informações pessoais. Se você tiver
-    alguma dúvida sobre como lidamos com dados do usuário e informações
-    pessoais, entre em contacto connosco.</span
-  >
-</p>
-<p><span style="color: rgb(68, 68, 68)"></span></p>
-<h3><span style="color: rgb(68, 68, 68)">Compromisso do Usuário</span></h3>
-<p>
-  <span style="color: rgb(68, 68, 68)"
-    >O usuário se compromete a fazer uso adequado dos conteúdos e da informação
-    que o NeuroApp oferece no site e com caráter enunciativo, mas não
-    limitativo:</span
-  >
-</p>
-<ul>
-  <li>
-    <span style="color: rgb(68, 68, 68)"
-      >A) Não se envolver em atividades que sejam ilegais ou contrárias à boa fé
-      a à ordem pública;</span
-    >
-  </li>
-  <li>
-    <span style="color: rgb(68, 68, 68)"
-      >B) Não difundir propaganda ou conteúdo de natureza racista, xenofóbica, </span
-    ><span style="color: rgb(33, 37, 41)"
-      ><a
-        href="https://betnacionalbrasil.br.com"
-        style="
-          color: inherit !important;
-          text-decoration: none !important;
-          font-size: inherit !important;
-        "
-        >Bet Nacional</a
-      ></span
-    ><span style="color: rgb(68, 68, 68)">
-      ou azar, qualquer tipo de pornografia ilegal, de apologia ao terrorismo ou
-      contra os direitos humanos;</span
-    >
-  </li>
-  <li>
-    <span style="color: rgb(68, 68, 68)"
-      >C) Não causar danos aos sistemas físicos (hardwares) e lógicos
-      (softwares) do NeuroApp, de seus fornecedores ou terceiros, para
-      introduzir ou disseminar vírus informáticos ou quaisquer outros sistemas
-      de hardware ou software que sejam capazes de causar danos anteriormente
-      mencionados.</span
-    >
-  </li>
-</ul>
-<h3><span style="color: rgb(68, 68, 68)">Mais informações</span></h3>
-<p>
-  <span style="color: rgb(68, 68, 68)"
-    >Esperemos que esteja esclarecido e, como mencionado anteriormente, se
-    houver algo que você não tem certeza se precisa ou não, geralmente é mais
-    seguro deixar os cookies ativados, caso interaja com um dos recursos que
-    você usa em nosso site.</span
-  >
-</p>
-<p>
-  <span style="color: rgb(68, 68, 68)"
-    >Esta política é efetiva a partir de&nbsp;17 March 2025 11:57</span
-  >
-</p>
+<div class="modal" (click)="closeModal($event)">
+  <div class="modal-content" (click)="closeModal($event)">
+    <h2>1. Política de Privacidade</h2>
+    <p>
+      A sua privacidade é importante para nós. É política do NeuroApp respeitar a sua privacidade em relação a qualquer informação sua que possamos coletar no site <a href="https://neuroapp.sa.pinheiro.tech/auth">NeuroApp</a>, e outros sites que possuímos e operamos.
+    </p>
+
+    <h2>2. Coleta de Informações</h2>
+    <p>
+      Solicitamos informações pessoais apenas quando realmente precisamos delas para lhe fornecer um serviço. Fazemo-lo por meios justos e legais, com o seu conhecimento e consentimento. Também informamos por que estamos coletando e como será usado.
+    </p>
+
+    <h2>3. Armazenamento de Dados</h2>
+    <p>
+      Apenas retemos as informações coletadas pelo tempo necessário para fornecer o serviço solicitado. Quando armazenamos dados, protegemos dentro de meios comercialmente aceitáveis ​​para evitar perdas e roubos, bem como acesso, divulgação, cópia, uso ou modificação não autorizados.
+    </p>
+
+    <h2>4. Compartilhamento de Informações</h2>
+    <p>
+      Não compartilhamos informações de identificação pessoal publicamente ou com terceiros, exceto quando exigido por lei.
+    </p>
+
+    <h2>5. Links Externos</h2>
+    <p>
+      O nosso site pode ter links para sites externos que não são operados por nós. Esteja ciente de que não temos controle sobre o conteúdo e práticas desses sites e não podemos aceitar responsabilidade por suas respectivas <a href="https://politicaprivacidade.com/" rel="noopener noreferrer" target="_blank">políticas de privacidade</a>.
+    </p>
+
+    <h2>6. Recusa de Informações</h2>
+    <p>
+      Você é livre para recusar a nossa solicitação de informações pessoais, entendendo que talvez não possamos fornecer alguns dos serviços desejados.
+    </p>
+
+    <h2>7. Aceitação dos Termos</h2>
+    <p>
+      O uso continuado de nosso site será considerado como aceitação de nossas práticas em torno de privacidade e informações pessoais. Se você tiver alguma dúvida sobre como lidamos com dados do usuário e informações pessoais, entre em contacto connosco.
+    </p>
+
+    <h3>Compromisso do Usuário</h3>
+    <p>
+      O usuário se compromete a fazer uso adequado dos conteúdos e da informação que o NeuroApp oferece no site e com caráter enunciativo, mas não limitativo:
+    </p>
+    <ul>
+      <li>
+        A) Não se envolver em atividades que sejam ilegais ou contrárias à boa fé a à ordem pública;
+      </li>
+      <li>
+        B) Não difundir propaganda ou conteúdo de natureza racista, xenofóbica, ou azar, qualquer tipo de pornografia ilegal, de apologia ao terrorismo ou contra os direitos humanos;
+      </li>
+      <li>
+        C) Não causar danos aos sistemas físicos (hardwares) e lógicos (softwares) do NeuroApp, de seus fornecedores ou terceiros, para introduzir ou disseminar vírus informáticos ou quaisquer outros sistemas de hardware ou software que sejam capazes de causar danos anteriormente mencionados.
+      </li>
+    </ul>
+
+    <h3>Mais Informações</h3>
+    <p>
+      Esperemos que esteja esclarecido e, como mencionado anteriormente, se houver algo que você não tem certeza se precisa ou não, geralmente é mais seguro deixar os cookies ativados, caso interaja com um dos recursos que você usa em nosso site.
+    </p>
+
+    <h3>Efetividade</h3>
+    <p>
+      Esta política é efetiva a partir de 17 March 2025 11:57.
+    </p>
+  </div>
+</div>

--- a/src/app/terms-modal/privacy-policy-modal/privacy-policy-modal.component.scss
+++ b/src/app/terms-modal/privacy-policy-modal/privacy-policy-modal.component.scss
@@ -1,0 +1,80 @@
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+  
+    .modal-content {
+      background-color: #fff;
+      padding: 2rem;
+      border-radius: 10px;
+      max-width: 800px;
+      width: 90%;
+      max-height: 90vh;
+      overflow-y: auto;
+      box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+      position: relative;
+  
+      .close-modal {
+        position: absolute;
+        top: 1rem;
+        right: 1rem;
+        font-size: 1.5rem;
+        font-weight: bold;
+        color: #444;
+        cursor: pointer;
+  
+        &:hover {
+          color: #000;
+        }
+      }
+  
+      h2, h3 {
+        color: #444;
+        margin-bottom: 1rem;
+      }
+  
+      h2 {
+        font-size: 1.5rem;
+        border-bottom: 2px solid #eee;
+        padding-bottom: 0.5rem;
+      }
+  
+      h3 {
+        font-size: 1.25rem;
+        margin-top: 1.5rem;
+      }
+  
+      p {
+        color: #666;
+        line-height: 1.6;
+        margin-bottom: 1rem;
+      }
+  
+      ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+  
+        li {
+          color: #666;
+          line-height: 1.6;
+          margin-bottom: 0.5rem;
+        }
+      }
+  
+      a {
+        color: #007bff;
+        text-decoration: none;
+  
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+    }
+  }

--- a/src/app/terms-modal/privacy-policy-modal/privacy-policy-modal.component.scss
+++ b/src/app/terms-modal/privacy-policy-modal/privacy-policy-modal.component.scss
@@ -25,13 +25,15 @@
         position: absolute;
         top: 1rem;
         right: 1rem;
+        background: none;
         font-size: 1.5rem;
         font-weight: bold;
-        color: #444;
         cursor: pointer;
-  
+        padding: 0;
+        line-height: 1;
+
         &:hover {
-          color: #000;
+          color: #d10000;
         }
       }
   

--- a/src/app/terms-modal/privacy-policy-modal/privacy-policy-modal.component.spec.ts
+++ b/src/app/terms-modal/privacy-policy-modal/privacy-policy-modal.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
+
+import { PrivacyPolicyModalComponent } from './privacy-policy-modal.component';
+
+describe('PrivacyPolicyModalComponent', () => {
+  let component: PrivacyPolicyModalComponent;
+  let fixture: ComponentFixture<PrivacyPolicyModalComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PrivacyPolicyModalComponent ],
+      imports: [IonicModule.forRoot()]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PrivacyPolicyModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/terms-modal/privacy-policy-modal/privacy-policy-modal.component.ts
+++ b/src/app/terms-modal/privacy-policy-modal/privacy-policy-modal.component.ts
@@ -1,0 +1,14 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-privacy-policy-modal',
+  templateUrl: './privacy-policy-modal.component.html',
+  styleUrls: ['./privacy-policy-modal.component.scss'],
+})
+export class PrivacyPolicyModalComponent  implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {}
+
+}

--- a/src/app/terms-modal/privacy-policy-modal/privacy-policy-modal.component.ts
+++ b/src/app/terms-modal/privacy-policy-modal/privacy-policy-modal.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ModalController } from '@ionic/angular';
 
 @Component({
   selector: 'app-privacy-policy-modal',
@@ -7,17 +8,12 @@ import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 })
 export class PrivacyPolicyModalComponent  implements OnInit {
 
-  @Output() close = new EventEmitter<void>();
-  
-  constructor() { }
+  constructor(private modalController: ModalController) { }
 
   ngOnInit() {}
 
-  closeModal(event: MouseEvent) {
-    const modalContent = document.querySelector('.modal-content');
-    if (event.target === event.currentTarget) {
-      this.close.emit();
-    }
+  async closeModal() {
+    await this.modalController.dismiss();
   }
 
 }

--- a/src/app/terms-modal/privacy-policy-modal/privacy-policy-modal.component.ts
+++ b/src/app/terms-modal/privacy-policy-modal/privacy-policy-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 
 @Component({
   selector: 'app-privacy-policy-modal',
@@ -7,8 +7,17 @@ import { Component, OnInit } from '@angular/core';
 })
 export class PrivacyPolicyModalComponent  implements OnInit {
 
+  @Output() close = new EventEmitter<void>();
+  
   constructor() { }
 
   ngOnInit() {}
+
+  closeModal(event: MouseEvent) {
+    const modalContent = document.querySelector('.modal-content');
+    if (event.target === event.currentTarget) {
+      this.close.emit();
+    }
+  }
 
 }

--- a/src/app/terms-modal/terms-of-use-modal/terms-of-use-modal.component.html
+++ b/src/app/terms-modal/terms-of-use-modal/terms-of-use-modal.component.html
@@ -1,0 +1,134 @@
+<h2><span style="color: rgb(68, 68, 68)">1. Termos</span></h2>
+<p>
+  <span style="color: rgb(68, 68, 68)"
+    >Ao acessar ao site
+    <a href="https://neuroapp.sa.pinheiro.tech/auth">NeuroApp</a>, concorda em
+    cumprir estes termos de serviço, todas as leis e regulamentos aplicáveis ​​e
+    concorda que é responsável pelo cumprimento de todas as leis locais
+    aplicáveis. Se você não concordar com algum desses termos, está proibido de
+    usar ou acessar este site. Os materiais contidos neste site são protegidos
+    pelas leis de direitos autorais e marcas comerciais aplicáveis.</span
+  >
+</p>
+<h2><span style="color: rgb(68, 68, 68)">2. Uso de Licença</span></h2>
+<p>
+  <span style="color: rgb(68, 68, 68)"
+    >É concedida permissão para baixar temporariamente uma cópia dos materiais
+    (informações ou software) no site NeuroApp , apenas para visualização
+    transitória pessoal e não comercial. Esta é a concessão de uma licença, não
+    uma transferência de título e, sob esta licença, você não pode:&nbsp;</span
+  >
+</p>
+<ol>
+  <li>
+    <span style="color: rgb(68, 68, 68)"
+      >modificar ou copiar os materiais;&nbsp;</span
+    >
+  </li>
+  <li>
+    <span style="color: rgb(68, 68, 68)"
+      >usar os materiais para qualquer finalidade comercial ou para exibição
+      pública (comercial ou não comercial);&nbsp;</span
+    >
+  </li>
+  <li>
+    <span style="color: rgb(68, 68, 68)"
+      >tentar descompilar ou fazer engenharia reversa de qualquer software
+      contido no site NeuroApp;&nbsp;</span
+    >
+  </li>
+  <li>
+    <span style="color: rgb(68, 68, 68)"
+      >remover quaisquer direitos autorais ou outras notações de propriedade dos
+      materiais; ou&nbsp;</span
+    >
+  </li>
+  <li>
+    <span style="color: rgb(68, 68, 68)"
+      >transferir os materiais para outra pessoa ou 'espelhe' os materiais em
+      qualquer outro servidor.</span
+    >
+  </li>
+</ol>
+<p>
+  <span style="color: rgb(68, 68, 68)"
+    >Esta licença será automaticamente rescindida se você violar alguma dessas
+    restrições e poderá ser rescindida por NeuroApp a qualquer momento. Ao
+    encerrar a visualização desses materiais ou após o término desta licença,
+    você deve apagar todos os materiais baixados em sua posse, seja em formato
+    eletrónico ou impresso.</span
+  >
+</p>
+<h2>
+  <span style="color: rgb(68, 68, 68)">3. Isenção de responsabilidade</span>
+</h2>
+<ol>
+  <li>
+    <span style="color: rgb(68, 68, 68)"
+      >Os materiais no site da NeuroApp são fornecidos 'como estão'. NeuroApp
+      não oferece garantias, expressas ou implícitas, e, por este meio, isenta e
+      nega todas as outras garantias, incluindo, sem limitação, garantias
+      implícitas ou condições de comercialização, adequação a um fim específico
+      ou não violação de propriedade intelectual ou outra violação de
+      direitos.</span
+    >
+  </li>
+  <li>
+    <span style="color: rgb(68, 68, 68)"
+      >Além disso, o NeuroApp não garante ou faz qualquer representação relativa
+      à precisão, aos resultados prováveis ​​ou à confiabilidade do uso dos
+      materiais em seu site ou de outra forma relacionado a esses materiais ou
+      em sites vinculados a este site.</span
+    >
+  </li>
+</ol>
+<h2><span style="color: rgb(68, 68, 68)">4. Limitações</span></h2>
+<p>
+  <span style="color: rgb(68, 68, 68)"
+    >Em nenhum caso o NeuroApp ou seus fornecedores serão responsáveis ​​por
+    quaisquer danos (incluindo, sem limitação, danos por perda de dados ou lucro
+    ou devido a interrupção dos negócios) decorrentes do uso ou da incapacidade
+    de usar os materiais em NeuroApp, mesmo que NeuroApp ou um representante
+    autorizado da NeuroApp tenha sido notificado oralmente ou por escrito da
+    possibilidade de tais danos. Como algumas jurisdições não permitem
+    limitações em garantias implícitas, ou limitações de responsabilidade por
+    danos conseqüentes ou incidentais, essas limitações podem não se aplicar a
+    você.</span
+  >
+</p>
+<h2><span style="color: rgb(68, 68, 68)">5. Precisão dos materiais</span></h2>
+<p>
+  <span style="color: rgb(68, 68, 68)"
+    >Os materiais exibidos no site da NeuroApp podem incluir erros técnicos,
+    tipográficos ou fotográficos. NeuroApp não garante que qualquer material em
+    seu site seja preciso, completo ou atual. NeuroApp pode fazer alterações nos
+    materiais contidos em seu site a qualquer momento, sem aviso prévio. No
+    entanto, NeuroApp não se compromete a atualizar os materiais.</span
+  >
+</p>
+<h2><span style="color: rgb(68, 68, 68)">6. Links</span></h2>
+<p>
+  <span style="color: rgb(68, 68, 68)"
+    >O NeuroApp não analisou todos os sites vinculados ao seu site e não é
+    responsável pelo conteúdo de nenhum site vinculado. A inclusão de qualquer
+    link não implica endosso por NeuroApp do site. O uso de qualquer site
+    vinculado é por conta e risco do usuário.</span
+  >
+</p>
+<p><br /></p>
+<h3><span style="color: rgb(68, 68, 68)">Modificações</span></h3>
+<p>
+  <span style="color: rgb(68, 68, 68)"
+    >O NeuroApp pode revisar estes termos de serviço do site a qualquer momento,
+    sem aviso prévio. Ao usar este site, você concorda em ficar vinculado à
+    versão atual desses termos de serviço.</span
+  >
+</p>
+<h3><span style="color: rgb(68, 68, 68)">Lei aplicável</span></h3>
+<p>
+  <span style="color: rgb(68, 68, 68)"
+    >Estes termos e condições são regidos e interpretados de acordo com as leis
+    do NeuroApp e você se submete irrevogavelmente à jurisdição exclusiva dos
+    tribunais naquele estado ou localidade.</span
+  >
+</p>

--- a/src/app/terms-modal/terms-of-use-modal/terms-of-use-modal.component.html
+++ b/src/app/terms-modal/terms-of-use-modal/terms-of-use-modal.component.html
@@ -1,5 +1,6 @@
-<div class="modal" (click)="closeModal($event)">
-  <div class="modal-content" (click)="closeModal($event)">
+<div class="modal" (click)="closeModal()">
+  <div class="modal-content">
+    <button class="close-modal" (click)="closeModal()">&times;</button>
     <h2>1. Termos</h2>
     <p>
       Ao acessar ao site <a href="https://neuroapp.sa.pinheiro.tech/auth">NeuroApp</a>, concorda em cumprir estes termos de serviço, todas as leis e regulamentos aplicáveis ​​e concorda que é responsável pelo cumprimento de todas as leis locais aplicáveis. Se você não concordar com algum desses termos, está proibido de usar ou acessar este site. Os materiais contidos neste site são protegidos pelas leis de direitos autorais e marcas comerciais aplicáveis.

--- a/src/app/terms-modal/terms-of-use-modal/terms-of-use-modal.component.html
+++ b/src/app/terms-modal/terms-of-use-modal/terms-of-use-modal.component.html
@@ -1,134 +1,58 @@
-<h2><span style="color: rgb(68, 68, 68)">1. Termos</span></h2>
-<p>
-  <span style="color: rgb(68, 68, 68)"
-    >Ao acessar ao site
-    <a href="https://neuroapp.sa.pinheiro.tech/auth">NeuroApp</a>, concorda em
-    cumprir estes termos de serviço, todas as leis e regulamentos aplicáveis ​​e
-    concorda que é responsável pelo cumprimento de todas as leis locais
-    aplicáveis. Se você não concordar com algum desses termos, está proibido de
-    usar ou acessar este site. Os materiais contidos neste site são protegidos
-    pelas leis de direitos autorais e marcas comerciais aplicáveis.</span
-  >
-</p>
-<h2><span style="color: rgb(68, 68, 68)">2. Uso de Licença</span></h2>
-<p>
-  <span style="color: rgb(68, 68, 68)"
-    >É concedida permissão para baixar temporariamente uma cópia dos materiais
-    (informações ou software) no site NeuroApp , apenas para visualização
-    transitória pessoal e não comercial. Esta é a concessão de uma licença, não
-    uma transferência de título e, sob esta licença, você não pode:&nbsp;</span
-  >
-</p>
-<ol>
-  <li>
-    <span style="color: rgb(68, 68, 68)"
-      >modificar ou copiar os materiais;&nbsp;</span
-    >
-  </li>
-  <li>
-    <span style="color: rgb(68, 68, 68)"
-      >usar os materiais para qualquer finalidade comercial ou para exibição
-      pública (comercial ou não comercial);&nbsp;</span
-    >
-  </li>
-  <li>
-    <span style="color: rgb(68, 68, 68)"
-      >tentar descompilar ou fazer engenharia reversa de qualquer software
-      contido no site NeuroApp;&nbsp;</span
-    >
-  </li>
-  <li>
-    <span style="color: rgb(68, 68, 68)"
-      >remover quaisquer direitos autorais ou outras notações de propriedade dos
-      materiais; ou&nbsp;</span
-    >
-  </li>
-  <li>
-    <span style="color: rgb(68, 68, 68)"
-      >transferir os materiais para outra pessoa ou 'espelhe' os materiais em
-      qualquer outro servidor.</span
-    >
-  </li>
-</ol>
-<p>
-  <span style="color: rgb(68, 68, 68)"
-    >Esta licença será automaticamente rescindida se você violar alguma dessas
-    restrições e poderá ser rescindida por NeuroApp a qualquer momento. Ao
-    encerrar a visualização desses materiais ou após o término desta licença,
-    você deve apagar todos os materiais baixados em sua posse, seja em formato
-    eletrónico ou impresso.</span
-  >
-</p>
-<h2>
-  <span style="color: rgb(68, 68, 68)">3. Isenção de responsabilidade</span>
-</h2>
-<ol>
-  <li>
-    <span style="color: rgb(68, 68, 68)"
-      >Os materiais no site da NeuroApp são fornecidos 'como estão'. NeuroApp
-      não oferece garantias, expressas ou implícitas, e, por este meio, isenta e
-      nega todas as outras garantias, incluindo, sem limitação, garantias
-      implícitas ou condições de comercialização, adequação a um fim específico
-      ou não violação de propriedade intelectual ou outra violação de
-      direitos.</span
-    >
-  </li>
-  <li>
-    <span style="color: rgb(68, 68, 68)"
-      >Além disso, o NeuroApp não garante ou faz qualquer representação relativa
-      à precisão, aos resultados prováveis ​​ou à confiabilidade do uso dos
-      materiais em seu site ou de outra forma relacionado a esses materiais ou
-      em sites vinculados a este site.</span
-    >
-  </li>
-</ol>
-<h2><span style="color: rgb(68, 68, 68)">4. Limitações</span></h2>
-<p>
-  <span style="color: rgb(68, 68, 68)"
-    >Em nenhum caso o NeuroApp ou seus fornecedores serão responsáveis ​​por
-    quaisquer danos (incluindo, sem limitação, danos por perda de dados ou lucro
-    ou devido a interrupção dos negócios) decorrentes do uso ou da incapacidade
-    de usar os materiais em NeuroApp, mesmo que NeuroApp ou um representante
-    autorizado da NeuroApp tenha sido notificado oralmente ou por escrito da
-    possibilidade de tais danos. Como algumas jurisdições não permitem
-    limitações em garantias implícitas, ou limitações de responsabilidade por
-    danos conseqüentes ou incidentais, essas limitações podem não se aplicar a
-    você.</span
-  >
-</p>
-<h2><span style="color: rgb(68, 68, 68)">5. Precisão dos materiais</span></h2>
-<p>
-  <span style="color: rgb(68, 68, 68)"
-    >Os materiais exibidos no site da NeuroApp podem incluir erros técnicos,
-    tipográficos ou fotográficos. NeuroApp não garante que qualquer material em
-    seu site seja preciso, completo ou atual. NeuroApp pode fazer alterações nos
-    materiais contidos em seu site a qualquer momento, sem aviso prévio. No
-    entanto, NeuroApp não se compromete a atualizar os materiais.</span
-  >
-</p>
-<h2><span style="color: rgb(68, 68, 68)">6. Links</span></h2>
-<p>
-  <span style="color: rgb(68, 68, 68)"
-    >O NeuroApp não analisou todos os sites vinculados ao seu site e não é
-    responsável pelo conteúdo de nenhum site vinculado. A inclusão de qualquer
-    link não implica endosso por NeuroApp do site. O uso de qualquer site
-    vinculado é por conta e risco do usuário.</span
-  >
-</p>
-<p><br /></p>
-<h3><span style="color: rgb(68, 68, 68)">Modificações</span></h3>
-<p>
-  <span style="color: rgb(68, 68, 68)"
-    >O NeuroApp pode revisar estes termos de serviço do site a qualquer momento,
-    sem aviso prévio. Ao usar este site, você concorda em ficar vinculado à
-    versão atual desses termos de serviço.</span
-  >
-</p>
-<h3><span style="color: rgb(68, 68, 68)">Lei aplicável</span></h3>
-<p>
-  <span style="color: rgb(68, 68, 68)"
-    >Estes termos e condições são regidos e interpretados de acordo com as leis
-    do NeuroApp e você se submete irrevogavelmente à jurisdição exclusiva dos
-    tribunais naquele estado ou localidade.</span
-  >
-</p>
+<div class="modal" (click)="closeModal($event)">
+  <div class="modal-content" (click)="closeModal($event)">
+    <h2>1. Termos</h2>
+    <p>
+      Ao acessar ao site <a href="https://neuroapp.sa.pinheiro.tech/auth">NeuroApp</a>, concorda em cumprir estes termos de serviço, todas as leis e regulamentos aplicáveis ​​e concorda que é responsável pelo cumprimento de todas as leis locais aplicáveis. Se você não concordar com algum desses termos, está proibido de usar ou acessar este site. Os materiais contidos neste site são protegidos pelas leis de direitos autorais e marcas comerciais aplicáveis.
+    </p>
+
+    <h2>2. Uso de Licença</h2>
+    <p>
+      É concedida permissão para baixar temporariamente uma cópia dos materiais (informações ou software) no site NeuroApp, apenas para visualização transitória pessoal e não comercial. Esta é a concessão de uma licença, não uma transferência de título e, sob esta licença, você não pode:
+    </p>
+    <ol>
+      <li>modificar ou copiar os materiais;</li>
+      <li>usar os materiais para qualquer finalidade comercial ou para exibição pública (comercial ou não comercial);</li>
+      <li>tentar descompilar ou fazer engenharia reversa de qualquer software contido no site NeuroApp;</li>
+      <li>remover quaisquer direitos autorais ou outras notações de propriedade dos materiais; ou</li>
+      <li>transferir os materiais para outra pessoa ou 'espelhe' os materiais em qualquer outro servidor.</li>
+    </ol>
+    <p>
+      Esta licença será automaticamente rescindida se você violar alguma dessas restrições e poderá ser rescindida por NeuroApp a qualquer momento. Ao encerrar a visualização desses materiais ou após o término desta licença, você deve apagar todos os materiais baixados em sua posse, seja em formato eletrónico ou impresso.
+    </p>
+
+    <h2>3. Isenção de responsabilidade</h2>
+    <ol>
+      <li>
+        Os materiais no site da NeuroApp são fornecidos 'como estão'. NeuroApp não oferece garantias, expressas ou implícitas, e, por este meio, isenta e nega todas as outras garantias, incluindo, sem limitação, garantias implícitas ou condições de comercialização, adequação a um fim específico ou não violação de propriedade intelectual ou outra violação de direitos.
+      </li>
+      <li>
+        Além disso, o NeuroApp não garante ou faz qualquer representação relativa à precisão, aos resultados prováveis ​​ou à confiabilidade do uso dos materiais em seu site ou de outra forma relacionado a esses materiais ou em sites vinculados a este site.
+      </li>
+    </ol>
+
+    <h2>4. Limitações</h2>
+    <p>
+      Em nenhum caso o NeuroApp ou seus fornecedores serão responsáveis ​​por quaisquer danos (incluindo, sem limitação, danos por perda de dados ou lucro ou devido a interrupção dos negócios) decorrentes do uso ou da incapacidade de usar os materiais em NeuroApp, mesmo que NeuroApp ou um representante autorizado da NeuroApp tenha sido notificado oralmente ou por escrito da possibilidade de tais danos. Como algumas jurisdições não permitem limitações em garantias implícitas, ou limitações de responsabilidade por danos conseqüentes ou incidentais, essas limitações podem não se aplicar a você.
+    </p>
+
+    <h2>5. Precisão dos materiais</h2>
+    <p>
+      Os materiais exibidos no site da NeuroApp podem incluir erros técnicos, tipográficos ou fotográficos. NeuroApp não garante que qualquer material em seu site seja preciso, completo ou atual. NeuroApp pode fazer alterações nos materiais contidos em seu site a qualquer momento, sem aviso prévio. No entanto, NeuroApp não se compromete a atualizar os materiais.
+    </p>
+
+    <h2>6. Links</h2>
+    <p>
+      O NeuroApp não analisou todos os sites vinculados ao seu site e não é responsável pelo conteúdo de nenhum site vinculado. A inclusão de qualquer link não implica endosso por NeuroApp do site. O uso de qualquer site vinculado é por conta e risco do usuário.
+    </p>
+
+    <h3>Modificações</h3>
+    <p>
+      O NeuroApp pode revisar estes termos de serviço do site a qualquer momento, sem aviso prévio. Ao usar este site, você concorda em ficar vinculado à versão atual desses termos de serviço.
+    </p>
+
+    <h3>Lei aplicável</h3>
+    <p>
+      Estes termos e condições são regidos e interpretados de acordo com as leis do NeuroApp e você se submete irrevogavelmente à jurisdição exclusiva dos tribunais naquele estado ou localidade.
+    </p>
+  </div>
+</div>

--- a/src/app/terms-modal/terms-of-use-modal/terms-of-use-modal.component.scss
+++ b/src/app/terms-modal/terms-of-use-modal/terms-of-use-modal.component.scss
@@ -1,0 +1,80 @@
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+  
+    .modal-content {
+      background-color: #fff;
+      padding: 2rem;
+      border-radius: 10px;
+      max-width: 800px;
+      width: 90%;
+      max-height: 90vh;
+      overflow-y: auto;
+      box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+      position: relative;
+  
+      .close-modal {
+        position: absolute;
+        top: 1rem;
+        right: 1rem;
+        font-size: 1.5rem;
+        font-weight: bold;
+        color: #444;
+        cursor: pointer;
+  
+        &:hover {
+          color: #000;
+        }
+      }
+  
+      h2, h3 {
+        color: #444;
+        margin-bottom: 1rem;
+      }
+  
+      h2 {
+        font-size: 1.5rem;
+        border-bottom: 2px solid #eee;
+        padding-bottom: 0.5rem;
+      }
+  
+      h3 {
+        font-size: 1.25rem;
+        margin-top: 1.5rem;
+      }
+  
+      p {
+        color: #666;
+        line-height: 1.6;
+        margin-bottom: 1rem;
+      }
+  
+      ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+  
+        li {
+          color: #666;
+          line-height: 1.6;
+          margin-bottom: 0.5rem;
+        }
+      }
+  
+      a {
+        color: #007bff;
+        text-decoration: none;
+  
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+    }
+  }

--- a/src/app/terms-modal/terms-of-use-modal/terms-of-use-modal.component.scss
+++ b/src/app/terms-modal/terms-of-use-modal/terms-of-use-modal.component.scss
@@ -25,13 +25,15 @@
         position: absolute;
         top: 1rem;
         right: 1rem;
+        background: none;
         font-size: 1.5rem;
         font-weight: bold;
-        color: #444;
         cursor: pointer;
-  
+        padding: 0;
+        line-height: 1;
+
         &:hover {
-          color: #000;
+          color: #d10000;
         }
       }
   

--- a/src/app/terms-modal/terms-of-use-modal/terms-of-use-modal.component.spec.ts
+++ b/src/app/terms-modal/terms-of-use-modal/terms-of-use-modal.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
+
+import { TermsOfUseModalComponent } from './terms-of-use-modal.component';
+
+describe('TermsOfUseModalComponent', () => {
+  let component: TermsOfUseModalComponent;
+  let fixture: ComponentFixture<TermsOfUseModalComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TermsOfUseModalComponent ],
+      imports: [IonicModule.forRoot()]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TermsOfUseModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/terms-modal/terms-of-use-modal/terms-of-use-modal.component.ts
+++ b/src/app/terms-modal/terms-of-use-modal/terms-of-use-modal.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ModalController } from '@ionic/angular';
 
 @Component({
   selector: 'app-terms-of-use-modal',
@@ -7,17 +8,12 @@ import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 })
 export class TermsOfUseModalComponent  implements OnInit {
 
-  @Output() close = new EventEmitter<void>();
-
-  constructor() { }
+  constructor(private modalController: ModalController) { }
 
   ngOnInit() {}
 
-  closeModal(event: MouseEvent) {
-    const modalContent = document.querySelector('.modal-content');
-    if (event.target === event.currentTarget) {
-      this.close.emit();
-    }
+  async closeModal() {
+    await this.modalController.dismiss();
   }
 
 }

--- a/src/app/terms-modal/terms-of-use-modal/terms-of-use-modal.component.ts
+++ b/src/app/terms-modal/terms-of-use-modal/terms-of-use-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 
 @Component({
   selector: 'app-terms-of-use-modal',
@@ -7,8 +7,17 @@ import { Component, OnInit } from '@angular/core';
 })
 export class TermsOfUseModalComponent  implements OnInit {
 
+  @Output() close = new EventEmitter<void>();
+
   constructor() { }
 
   ngOnInit() {}
+
+  closeModal(event: MouseEvent) {
+    const modalContent = document.querySelector('.modal-content');
+    if (event.target === event.currentTarget) {
+      this.close.emit();
+    }
+  }
 
 }

--- a/src/app/terms-modal/terms-of-use-modal/terms-of-use-modal.component.ts
+++ b/src/app/terms-modal/terms-of-use-modal/terms-of-use-modal.component.ts
@@ -1,0 +1,14 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-terms-of-use-modal',
+  templateUrl: './terms-of-use-modal.component.html',
+  styleUrls: ['./terms-of-use-modal.component.scss'],
+})
+export class TermsOfUseModalComponent  implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {}
+
+}


### PR DESCRIPTION
## Descrição

Este PR adiciona os componentes **Termos de Uso** e **Política de Privacidade** ao projeto. Esses componentes são exibidos em modais e podem ser acessados a partir da interface do usuário.

### O que foi feito

- Componente de Termos de Uso
- Componente de Política de Privacidade
- Service de Termos
- Associação entre user e termos aceitos
- Tabela 'terms_acceptance'

### Observações

- Os textos foram gerados automaticamente no site [PolíticaPrivacidade](https://politicaprivacidade.com/)

### Issue

[#24](https://github.com/dotpinheiro/neuro-app/issues/24)
