### PR TITLE
fix: remove campo de horario nos formularios de medicacao

### DIFF
--- a/src/app/additional-info/additional-info.page.html
+++ b/src/app/additional-info/additional-info.page.html
@@ -62,16 +62,21 @@
         <p>Quando você começou a tomar medicações?</p>
       </div>
 
-      <div class="form-input-full">
-
-        <ion-datetime-button class="form-input" datetime="datetime"></ion-datetime-button>
-
-        <ion-modal [keepContentsMounted]="true">
-          <ng-template>
-            <ion-datetime id="datetime" formControlName="medication_started_at"></ion-datetime>
-          </ng-template>
-        </ion-modal>
-      </div>
+     <div class="form-input-full">
+      <ion-datetime-button class="form-input" datetime="datetime"></ion-datetime-button>
+      <ion-modal [keepContentsMounted]="true">
+        <ng-template>
+          <ion-datetime
+            id="datetime"
+            formControlName="medication_started_at"
+            presentation="date"
+            [disabled]="isLoading"
+            aria-label="Data de início da medicação"
+            preferWheel="false"
+          ></ion-datetime>
+        </ng-template>
+      </ion-modal>
+    </div>
     </div>
 
     <div class="image-container">

--- a/src/app/additional-info/additional-info.page.ts
+++ b/src/app/additional-info/additional-info.page.ts
@@ -52,6 +52,9 @@ export class AdditionalInfoPage implements OnInit {
     try{
       this.isLoading = true;
       const userData: ProfileInterface = this.form.value as ProfileInterface;
+      if(userData.medication_started_at) {
+        userData.medication_started_at = userData.medication_started_at.split('T')[0];
+      }
       await this._profileService.createProfile(userData);
       await this._router.navigate(['/tabs/medications']);
     }catch (e: any){

--- a/src/app/profile/profile.page.html
+++ b/src/app/profile/profile.page.html
@@ -62,20 +62,20 @@
       </div>
 
       <div class="form-input-full">
-        <ion-datetime-button
-          class="form-input"
-          datetime="datetime"
-        ></ion-datetime-button>
-
+        <ion-datetime-button class="form-input" datetime="datetime"></ion-datetime-button>
         <ion-modal [keepContentsMounted]="true">
           <ng-template>
             <ion-datetime
               id="datetime"
               formControlName="medication_started_at"
+              presentation="date"
+              [disabled]="isLoading"
+              aria-label="Data de início da medicação"
+              preferWheel="false"
             ></ion-datetime>
           </ng-template>
         </ion-modal>
-      </div>
+    </div>
     </div>
 
     <div class="button-container">


### PR DESCRIPTION
## Modificações

- Ajustado os formulários para permitir selecionar apenas a data no campo "Quando você começou a tomar medicações?".
- No submit, o valor enviado para o backend agora contém somente a data (YYYY-MM-DD), sem horário.

![image](https://github.com/user-attachments/assets/44f2707b-5c75-499f-8c7a-8984a1323520)
